### PR TITLE
Pthread's locks replaced by lock-free atomic code

### DIFF
--- a/Superpowered/SuperpoweredAndroidAudioIO.cpp
+++ b/Superpowered/SuperpoweredAndroidAudioIO.cpp
@@ -226,6 +226,5 @@ SuperpoweredAndroidAudioIO::~SuperpoweredAndroidAudioIO() {
 
     free(internals->fifobuffer);
     free(internals->silence);
-    //pthread_mutex_destroy(&internals->mutex);
     delete internals;
 }


### PR DESCRIPTION
Using widely available C++11 atomic prmitives.

This yields to even less latency.