### PR TITLE
Better interaction with other audio players and app rejection fix

### DIFF
--- a/Superpowered/SuperpoweredIOSAudioIO.h
+++ b/Superpowered/SuperpoweredIOSAudioIO.h
@@ -88,13 +88,15 @@ typedef bool (*audioProcessingCallback) (void *clientdata, float **buffers, unsi
  */
 @interface SuperpoweredIOSAudioIO: NSObject {
     int preferredBufferSizeMs;
-    bool saveBatteryInBackground;
+    bool saveBatteryInBackground, activateSessionOnForeground;
 }
 
 /** @brief The preferred buffer size. Recommended: 12. */
 @property (nonatomic, assign) int preferredBufferSizeMs;
 /** @brief Save battery if output is silence and the app runs in background mode. True by default. */
 @property (nonatomic, assign) bool saveBatteryInBackground;
+/** @brief If true, when your app returns to the foreground, other music player apps will immediately stop playing.  True by default. */
+@property (nonatomic, assign) bool activateSessionOnForeground;
 
 /**
  @brief Creates the audio output instance.

--- a/Superpowered/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/SuperpoweredIOSAudioIO.mm
@@ -41,7 +41,7 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
     bool audioUnitRunning, iOS6, background, inputEnabled;
 }
 
-@synthesize preferredBufferSizeMs, saveBatteryInBackground;
+@synthesize preferredBufferSizeMs, saveBatteryInBackground, activateSessionOnForeground;
 
 - (void)createAudioBuffersForRecordingCategory {
     inputBufferListForRecordingCategory = (AudioBufferList *)malloc(sizeof(AudioBufferList) + (sizeof(AudioBuffer) * numChannels));
@@ -64,6 +64,7 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
         audioSessionCategory = category;
 #endif
         saveBatteryInBackground = true;
+        activateSessionOnForeground = true;
         preferredBufferSizeMs = preferredBufferSize;
         preferredMinimumSamplerate = prefsamplerate;
         bool recordOnly = [category isEqualToString:AVAudioSessionCategoryRecord];
@@ -178,7 +179,8 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
 - (void)onForeground { // App comes foreground.
     if (background) {
         background = false;
-        [self endInterruption];
+        if (activateSessionOnForeground)
+            [self endInterruption];
     };
 }
 
@@ -409,6 +411,7 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
     if (audioUnit == NULL) return false;
     if (AudioOutputUnitStart(audioUnit)) return false;
     audioUnitRunning = true;
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
     return true;
 }
 

--- a/Superpowered/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/SuperpoweredIOSAudioIO.mm
@@ -167,7 +167,11 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
             if (audioUnitRunning) [self performSelectorOnMainThread:@selector(startDelegateInterruption) withObject:nil waitUntilDone:NO];
             [self beginInterruption];
             break;
-        case AVAudioSessionInterruptionTypeEnded: [self endInterruption]; break;
+        case AVAudioSessionInterruptionTypeEnded:
+            NSNumber *shouldResume = [notification.userInfo objectForKey:AVAudioSessionInterruptionOptionKey];
+            if ((shouldResume == nil) || [shouldResume unsignedIntegerValue] == AVAudioSessionInterruptionOptionShouldResume)
+                [self endInterruption];
+            break;
     };
 }
 


### PR DESCRIPTION
This pull request fixes a couple issues I was having with SuperpoweredIOSAudioIO:
1.  When another music player (such as Pandora) was playing audio, when my app was brought to the foreground, the other app immediately stopped playback, even though my app was not yet playing an audio.  My preferred behavior was for the other app to continue playing audio until the user started playback in my app.
2. When my app's audio was interrupted by another music player starting audio, if that music player later stopped and the user re-opened my app, my app would automatically begin playback.  This is not the desired behavior.  I want my app to continue playback after an interruption only if the interruption was due to something like an incoming phone call.
