### PR TITLE
Silence "missing submodule" warning

### DIFF
--- a/Superpowered/SuperpoweredIOSAudioIO.h
+++ b/Superpowered/SuperpoweredIOSAudioIO.h
@@ -1,4 +1,4 @@
-#import <AVFoundation/AVAudioSession.h>
+#import <AVFoundation/AVFoundation.h>
 
 /**
  @brief Output channel mapping.


### PR DESCRIPTION
Silences `missing submodule 'AVFoundation.AVAudioSession'` Xcode Swift Compiler Warning (Xcode 8.3.2)