### PR TITLE
Add import to support latest NDK

### DIFF
--- a/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.cpp
+++ b/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.cpp
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <cstring>
 
 #define NUM_CHANNELS 2
 


### PR DESCRIPTION
To fix the "Can't resolve variable 'memset'" errors that were happening after upgrading to latest Android Studio and NDK.